### PR TITLE
[pages] Add Error, Login Page Expired, and Terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Keywind is a component-based Keycloak Login Theme built with [Tailwind CSS](http
 
 ### Styled Pages
 
+- Error
 - Login
 - Login Config TOTP
 - Login Expired

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Keywind is a component-based Keycloak Login Theme built with [Tailwind CSS](http
 - Logout Confirm
 - Register
 - Select Authenticator
+- Terms and Conditions
 - WebAuthn Authenticate
 - WebAuthn Error
 - WebAuthn Register

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Keywind is a component-based Keycloak Login Theme built with [Tailwind CSS](http
 
 - Login
 - Login Config TOTP
+- Login Expired
 - Login IDP Link Confirm
 - Login OAuth Grant
 - Login OTP

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Keywind is a component-based Keycloak Login Theme built with [Tailwind CSS](http
 - Error
 - Login
 - Login Config TOTP
-- Login Expired
 - Login IDP Link Confirm
 - Login OAuth Grant
 - Login OTP
+- Login Page Expired
 - Login Recovery Authn Code Config
 - Login Recovery Authn Code Input
 - Login Reset Password

--- a/theme/keywind/login/error.ftl
+++ b/theme/keywind/login/error.ftl
@@ -1,20 +1,18 @@
 <#import "template.ftl" as layout>
-<#import "components/atoms/button.ftl" as button>
-<#import "components/atoms/button-group.ftl" as buttonGroup>
+<#import "components/atoms/alert.ftl" as alert>
+<#import "components/atoms/link.ftl" as link>
 
-<@layout.registrationLayout displayInfo=true displayMessage=false; section>
+<@layout.registrationLayout displayMessage=false; section>
   <#if section="header">
-    ${msg("errorTitle")}
+    ${kcSanitize(msg("errorTitle"))?no_esc}
   <#elseif section="form">
-    ${kcSanitize(message.summary)}
-  <#elseif section="info">
-    <@buttonGroup.kw>
-      <@button.kw component="a" color="primary" href=client.baseUrl>
-        ${kcSanitize(msg("backToApplication"))?no_esc}
-      </@button.kw>
-      <@button.kw component="a" color="secondary" href=url.loginUrl>
-        ${kcSanitize(msg("backToLogin"))?no_esc}
-      </@button.kw>
-    </@buttonGroup.kw>
+    <@alert.kw color="error">${kcSanitize(message.summary)?no_esc}</@alert.kw>
+    <#if !skipLink??>
+      <#if client?? && client.baseUrl?has_content>
+        <@link.kw color="secondary" href=client.baseUrl size="small">
+          ${kcSanitize(msg("backToApplication"))?no_esc}
+        </@link.kw>
+      </#if>
+    </#if>
   </#if>
 </@layout.registrationLayout>

--- a/theme/keywind/login/error.ftl
+++ b/theme/keywind/login/error.ftl
@@ -1,0 +1,20 @@
+<#import "template.ftl" as layout>
+<#import "components/atoms/button.ftl" as button>
+<#import "components/atoms/button-group.ftl" as buttonGroup>
+
+<@layout.registrationLayout displayInfo=true displayMessage=false; section>
+  <#if section="header">
+    ${msg("errorTitle")}
+  <#elseif section="form">
+    ${kcSanitize(message.summary)}
+  <#elseif section="info">
+    <@buttonGroup.kw>
+      <@button.kw component="a" color="primary" href=client.baseUrl>
+        ${kcSanitize(msg("backToApplication"))?no_esc}
+      </@button.kw>
+      <@button.kw component="a" color="secondary" href=url.loginUrl>
+        ${kcSanitize(msg("backToLogin"))?no_esc}
+      </@button.kw>
+    </@buttonGroup.kw>
+  </#if>
+</@layout.registrationLayout>

--- a/theme/keywind/login/login-page-expired.ftl
+++ b/theme/keywind/login/login-page-expired.ftl
@@ -1,0 +1,23 @@
+<#import "template.ftl" as layout>
+<#import "components/atoms/link.ftl" as link>
+
+<@layout.registrationLayout displayInfo=true displayMessage=false; section>
+  <#if section="header">
+    ${msg("pageExpiredTitle")}
+  <#elseif section="info">
+    <div class="space-y-4">
+      <div class="flex space-x-1">
+        <span>${msg("pageExpiredMsg1")}:</span>
+        <@link.kw color="primary" href=url.loginRestartFlowUrl>
+          ${msg("doClickHere")}
+        </@link.kw>
+      </div>
+      <div class="flex space-x-1">
+        <span>${msg("pageExpiredMsg2")}:</span>
+        <@link.kw color="primary" href=url.loginAction>
+          ${msg("doClickHere")}
+        </@link.kw>
+      </div>
+    </div>
+  </#if>
+</@layout.registrationLayout>

--- a/theme/keywind/login/login-page-expired.ftl
+++ b/theme/keywind/login/login-page-expired.ftl
@@ -1,22 +1,28 @@
 <#import "template.ftl" as layout>
 <#import "components/atoms/link.ftl" as link>
+<#import "components/atoms/button.ftl" as button>
+<#import "components/atoms/button-group.ftl" as buttonGroup>
 
 <@layout.registrationLayout displayInfo=true displayMessage=false; section>
   <#if section="header">
     ${msg("pageExpiredTitle")}
   <#elseif section="info">
     <div class="space-y-4">
-      <div class="flex space-x-1">
-        <span>${msg("pageExpiredMsg1")}:</span>
-        <@link.kw color="primary" href=url.loginRestartFlowUrl>
-          ${msg("doClickHere")}
-        </@link.kw>
+      <div>
+        ${msg("pageExpiredMsg1")}:
+        <@buttonGroup.kw>
+          <@button.kw component="a" color="primary" href=url.loginRestartFlowUrl>
+            ${msg("doClickHere")}
+          </@button.kw>
+        </@buttonGroup.kw>
       </div>
-      <div class="flex space-x-1">
-        <span>${msg("pageExpiredMsg2")}:</span>
-        <@link.kw color="primary" href=url.loginAction>
-          ${msg("doClickHere")}
-        </@link.kw>
+      <div>
+        ${msg("pageExpiredMsg2")}:
+        <@buttonGroup.kw>
+          <@button.kw component="a" color="secondary" href=url.loginAction>
+            ${msg("doClickHere")}
+          </@button.kw>
+        </@buttonGroup.kw>
       </div>
     </div>
   </#if>

--- a/theme/keywind/login/login-page-expired.ftl
+++ b/theme/keywind/login/login-page-expired.ftl
@@ -1,29 +1,18 @@
 <#import "template.ftl" as layout>
-<#import "components/atoms/link.ftl" as link>
 <#import "components/atoms/button.ftl" as button>
 <#import "components/atoms/button-group.ftl" as buttonGroup>
 
-<@layout.registrationLayout displayInfo=true displayMessage=false; section>
+<@layout.registrationLayout; section>
   <#if section="header">
     ${msg("pageExpiredTitle")}
-  <#elseif section="info">
-    <div class="space-y-4">
-      <div>
-        ${msg("pageExpiredMsg1")}:
-        <@buttonGroup.kw>
-          <@button.kw component="a" color="primary" href=url.loginRestartFlowUrl>
-            ${msg("doClickHere")}
-          </@button.kw>
-        </@buttonGroup.kw>
-      </div>
-      <div>
-        ${msg("pageExpiredMsg2")}:
-        <@buttonGroup.kw>
-          <@button.kw component="a" color="secondary" href=url.loginAction>
-            ${msg("doClickHere")}
-          </@button.kw>
-        </@buttonGroup.kw>
-      </div>
-    </div>
+  <#elseif section="form">
+    <@buttonGroup.kw>
+      <@button.kw color="primary" component="a" href=url.loginRestartFlowUrl>
+        ${msg("doTryAgain")}
+      </@button.kw>
+      <@button.kw color="secondary" component="a" href=url.loginAction>
+        ${msg("doContinue")}
+      </@button.kw>
+    </@buttonGroup.kw>
   </#if>
 </@layout.registrationLayout>

--- a/theme/keywind/login/terms.ftl
+++ b/theme/keywind/login/terms.ftl
@@ -1,0 +1,23 @@
+<#import "template.ftl" as layout>
+<#import "components/atoms/button.ftl" as button>
+<#import "components/atoms/button-group.ftl" as buttonGroup>
+<#import "components/atoms/form.ftl" as form>
+
+<@layout.registrationLayout displayInfo=true displayMessage=false; section>
+  <#if section="header">
+    ${msg("termsTitle")}
+  <#elseif section="form">
+    ${kcSanitize(msg("termsText"))?no_esc}
+  <#elseif section="info">
+    <@form.kw action=url.loginAction method="post">
+      <@buttonGroup.kw>
+        <@button.kw color="primary" name="accept" type="submit">
+          ${msg("doAccept")}
+        </@button.kw>
+        <@button.kw color="secondary" name="cancel" type="submit">
+          ${msg("doDecline")}
+        </@button.kw>
+      </@buttonGroup.kw>
+    </@form.kw>
+  </#if>
+</@layout.registrationLayout>

--- a/theme/keywind/login/terms.ftl
+++ b/theme/keywind/login/terms.ftl
@@ -3,12 +3,11 @@
 <#import "components/atoms/button-group.ftl" as buttonGroup>
 <#import "components/atoms/form.ftl" as form>
 
-<@layout.registrationLayout displayInfo=true displayMessage=false; section>
+<@layout.registrationLayout displayMessage=false; section>
   <#if section="header">
     ${msg("termsTitle")}
   <#elseif section="form">
     ${kcSanitize(msg("termsText"))?no_esc}
-  <#elseif section="info">
     <@form.kw action=url.loginAction method="post">
       <@buttonGroup.kw>
         <@button.kw color="primary" name="accept" type="submit">


### PR DESCRIPTION
Hi,

I previously forked this project for some customization but don't have time and needs to maintain it. I tried to adapt a couple of pages to this project.
This includes (for now) the error page, the login expired page and the TaC page:

![error](https://user-images.githubusercontent.com/7892612/218254797-7f37808f-0d8b-40e4-a0ed-b3822430053e.png)
![login expired](https://user-images.githubusercontent.com/7892612/218254799-c51cfd5a-e569-4e97-bd49-ae7533f1641e.png)
![terms](https://user-images.githubusercontent.com/7892612/218254800-1c8dc4bf-50a6-4677-9a78-b76678540b11.png)

I am a bit unhappy about the login expired page and maybe you have some ideas on how to make it look good. ^^

Thanks in advance!