### PR TITLE
Update LinkedIn alias to linkedin-openid-connect

### DIFF
--- a/theme/keywind/login/assets/providers/providers.ftl
+++ b/theme/keywind/login/assets/providers/providers.ftl
@@ -47,7 +47,7 @@
   <@instagramIcon.kw />
 </#macro>
 
-<#macro linkedin>
+<#macro "linkedin-openid-connect">
   <@linkedinIcon.kw />
 </#macro>
 

--- a/theme/keywind/login/components/molecules/identity-provider.ftl
+++ b/theme/keywind/login/components/molecules/identity-provider.ftl
@@ -31,7 +31,7 @@
         <#case "instagram">
           <#assign colorClass="hover:bg-provider-instagram/10">
           <#break>
-        <#case "linkedin">
+        <#case "linkedin-openid-connect">
           <#assign colorClass="hover:bg-provider-linkedin/10">
           <#break>
         <#case "microsoft">


### PR DESCRIPTION
In Keycloak 22, the LinkedIn provider alias is set to linkedin-openid-connect so the LinkedIn icon is broken. This change ensures the icon renders correctly on v22.