### PR TITLE
Add formnovalidate attribute to ignore required fields on update password page

### DIFF
--- a/theme/keywind/login/login-update-password.ftl
+++ b/theme/keywind/login/login-update-password.ftl
@@ -50,7 +50,7 @@
           <@button.kw color="primary" type="submit">
             ${msg("doSubmit")}
           </@button.kw>
-          <@button.kw color="secondary" name="cancel-aia" type="submit" value="true">
+          <@button.kw color="secondary" name="cancel-aia" type="submit" value="true" formnovalidate="formnovalidate">
             ${msg("doCancel")}
           </@button.kw>
         <#else>


### PR DESCRIPTION
Issue: Update password form validates empty fields when I click a cancel button. Validations have to be skipped when a user clicks this button.

Changes:
 * Added `formnovalidate` attribute to the cancel button on update password page.