### PR TITLE
Add template for device flow page

### DIFF
--- a/theme/keywind/login/login-oauth2-device-verify-user-code.ftl
+++ b/theme/keywind/login/login-oauth2-device-verify-user-code.ftl
@@ -1,0 +1,28 @@
+<#import "template.ftl" as layout>
+<#import "components/atoms/button.ftl" as button>
+<#import "components/atoms/button-group.ftl" as buttonGroup>
+<#import "components/atoms/form.ftl" as form>
+<#import "components/atoms/input.ftl" as input>
+
+<@layout.registrationLayout; section>
+  <#if section = "header">
+    ${msg("oauth2DeviceVerificationTitle")}
+  <#elseif section = "form">
+    <@form.kw action=url.oauth2DeviceVerificationAction method="post">
+      <@input.kw
+        autocomplete="off"
+        autofocus=true
+        label=msg("verifyOAuth2DeviceUserCode")
+        name="device_user_code"
+        type="text"
+        dir="ltr"
+      />
+
+      <@buttonGroup.kw>
+        <@button.kw color="primary" name="submitAction" type="submit">
+          ${msg("doSubmit")}
+        </@button.kw>
+      </@buttonGroup.kw>
+    </@form.kw>
+  </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
I noticed theme missing template for device flow (available at `/realms/master/protocol/openid-connect/auth/device`), so here we are.

Old (inherited from `base` theme):
![Screenshot from 2024-06-14 06-32-20](https://github.com/lukin/keywind/assets/1416030/6f12d977-88ad-4279-9873-ed7c536e796e)

Shiny new one:
![Screenshot from 2024-06-14 06-32-29](https://github.com/lukin/keywind/assets/1416030/e2f3a91a-1618-4650-a4ad-d40f388048ed)
