### PR TITLE
fix: only show identity-provider section when providers are configured

### DIFF
--- a/theme/keywind/login/login-username.ftl
+++ b/theme/keywind/login/login-username.ftl
@@ -64,7 +64,7 @@
       </div>
     </#if>
   <#elseif section="socialProviders">
-    <#if realm.password && social.providers??>
+    <#if realm.password && social.providers?? && social.providers?has_content>
       <@identityProvider.kw providers=social.providers />
     </#if>
   </#if>

--- a/theme/keywind/login/login.ftl
+++ b/theme/keywind/login/login.ftl
@@ -80,7 +80,7 @@
       </div>
     </#if>
   <#elseif section="socialProviders">
-    <#if realm.password && social.providers??>
+    <#if realm.password && social.providers?? && social.providers?has_content>
       <@identityProvider.kw providers=social.providers />
     </#if>
   </#if>


### PR DESCRIPTION
I noticed that in Keycloak v26.0.3 the identity‐provider section was still rendered even when no providers were configured. This change makes that section appear only if `social.providers` contains content.

Before
<img width="636" height="528" alt="image" src="https://github.com/user-attachments/assets/c1485ddc-f3c4-40c6-bc95-d0eae4b6e363" />

After
<img width="636" height="528" alt="image" src="https://github.com/user-attachments/assets/79059968-7e41-47f3-856e-92cc83e923be" />

